### PR TITLE
Feature - Fill in missing raster values

### DIFF
--- a/qgis/src/services/raster_service.py
+++ b/qgis/src/services/raster_service.py
@@ -180,7 +180,7 @@ class RasterService:
 
     def fill_nodata_gdal(
         self,
-        input_raster: QgsRasterLayer,
+        input_raster_path: str,
         output_path: str,
         band: int = 1,
         distance: float = 10,
@@ -207,7 +207,7 @@ class RasterService:
         feedback = QgsProcessingFeedback()
 
         params = {
-            'INPUT': input_raster,
+            'INPUT': input_raster_path,
             'BAND': band,
             'DISTANCE': distance,
             'ITERATIONS': iterations,


### PR DESCRIPTION
# Description
Up until now when you regenerate the map we had big gaps like this:
<img width="1963" height="842" alt="Screenshot 2025-11-26 090901" src="https://github.com/user-attachments/assets/ddcdfffd-cfa7-4f53-81e6-a3b4ec5975fe" />

Apparently the issue stems from the quality of the SVF layer that we got from KNMI. Therefore the shadow and sun pet layers were broken as well. To fix this when the full map is generated, the gaps in the SVF were filled. Now it looks a lot more presentable

<img width="1347" height="755" alt="Screenshot 2025-11-26 092933" src="https://github.com/user-attachments/assets/c36dd1bb-0df7-4a55-bf1d-cd0b17530dfa" />

# What needs to be tested
- [x] Run the following request and wait to tell you that the map is regenerated: GET `localhost:9000/pet/full-map-generation` (You will not see the results immediately so don't panic)
- [x] Place/remove a tree so that you can send a request to the backend to update and wait for it
- [x] The new map you see should resemble the second screenshot above

