### PR TITLE
Bugfix: Serving trees

### DIFF
--- a/backend/src/api/controllers/abstract_server_controller.py
+++ b/backend/src/api/controllers/abstract_server_controller.py
@@ -2,7 +2,6 @@ from abc import ABC
 from fastapi import Response
 from src.api.exceptions import QgisServerException
 from src.api.requests import ServerRequest
-from typing import Optional
 import httpx
 import os
 import re
@@ -13,12 +12,12 @@ class AbstractServerController(ABC):
     Handles shared configuration and the generic HTTP request logic.
     """
     # Shared Configuration
-    QGIS_SERVER_BASE_URL: str = os.getenv('QGIS_SERVER_URL', 'http://nginx/')
+    QGIS_SERVER_BASE_URL: str = os.getenv('QGIS_SERVER_URL', 'http://nginx/nginx')
     QGIS_TIMEOUT: float = 30.0
     TARGET_CRS: str = "EPSG:28992"
     BBOX_REGEX: re.Pattern = re.compile(r"^\s*[-+]?\d+(\.\d+)?\s*,\s*[-+]?\d+(\.\d+)?\s*,\s*[-+]?\d+(\.\d+)?\s*,\s*[-+]?\d+(\.\d+)?\s*$")
 
-    async def get_resource(self, request_data: ServerRequest, session_id: Optional[str], path: str = '') -> Response:
+    async def get_resource(self, request_data: ServerRequest, session_id: str, path: str = '') -> Response:
         """
         Makes an asynchronous GET request to the QGIS Server using the
         parameters derived from any ServerRequest model.
@@ -34,7 +33,7 @@ class AbstractServerController(ABC):
         if request_data.__pydantic_extra__:
              params_dict.update(request_data.__pydantic_extra__)
         
-        full_url = f"{self.QGIS_SERVER_BASE_URL}nginx/{session_id}/wfs{path}"
+        full_url = f"{self.QGIS_SERVER_BASE_URL}/{session_id}/{path}"
         async with httpx.AsyncClient() as client:
             try:
                 qgis_response = await client.get(full_url, params=params_dict, timeout=self.QGIS_TIMEOUT)

--- a/backend/src/api/controllers/wfs_controller.py
+++ b/backend/src/api/controllers/wfs_controller.py
@@ -2,7 +2,6 @@ from fastapi import HTTPException, Response
 from src.api.controllers import AbstractServerController
 from src.api.models import WFSParams
 from src.api.requests import (
-    ServerRequest,
     WFSRequest,
 )
 from typing import Optional
@@ -12,7 +11,7 @@ class WFSController(AbstractServerController):
     Controller specialized for WFS GetFeature requests (e.g., fetching GeoJSON).
     """
     
-    async def get_features(self, type: str, params: WFSParams, session_id: Optional[str]) -> Response:
+    async def get_features(self, type: str, params: WFSParams) -> Response:
         """
         Constructs the necessary WFS ServerRequest based on user input and fetches the data.
         """
@@ -23,7 +22,7 @@ class WFSController(AbstractServerController):
             if not self.BBOX_REGEX.match(params.bbox):
                 raise HTTPException(status_code=422, detail="Invalid BBOX format. Expected 'minX,minY,maxX,maxY'.")
             
-            bbox_param = f"{params.bbox},{self.TARGET_CRS}" 
+            bbox_param = f"{params.bbox}" 
             
         wfs_request = WFSRequest(
             TYPENAME=type,  # The requested layer name
@@ -31,5 +30,5 @@ class WFSController(AbstractServerController):
             SRSNAME=self.TARGET_CRS,
             OUTPUTFORMAT='application/json',
         )
-        
-        return await self.get_resource(request_data=wfs_request, session_id=session_id)
+
+        return await self.get_resource(request_data=wfs_request, session_id="starting-map", path="wfs")

--- a/backend/src/api/router.py
+++ b/backend/src/api/router.py
@@ -31,12 +31,10 @@ def add_measures(
 async def get_objects_by_type(
     type: str,
     params: WFSParams = Depends(),
-    session_id: Optional[str] = Cookie(default=None),
 ):
     return await wfs_controller.get_features(
         type=type,
         params=params,
-        session_id=session_id,
     )
 
 @api_router.get("/session/init")

--- a/frontend/src/map/utils/deckUtils.ts
+++ b/frontend/src/map/utils/deckUtils.ts
@@ -1,6 +1,8 @@
 import type { Mesh, MeshAttribute } from '@loaders.gl/schema';
 
 export const BBOX = "31593.331,391390.397,32093.331,391890.397";
+// BBOX for entire Middelburg, in case we need it later:
+// export const BBOX = "30000.0074047316,387498.9925012316,34999.99884920326,393749.9992063424";
 export const LOCAL_STORAGE_KEY = 'userPlacedObjects';
 export const DEFAULT_OBJECT_TYPE = 'Trees';
 

--- a/server/conf/nginx-fcgi-sample.conf
+++ b/server/conf/nginx-fcgi-sample.conf
@@ -81,6 +81,19 @@ http {
         listen       [::]:80 default_server;
         server_name  _;
 
+        location ~ ^/nginx/starting-map/(.*)$ {
+            fastcgi_pass  qgis-fcgi;
+
+            set $qgis_project_path /io/data/server/map.qgz;
+
+            fastcgi_param SCRIPT_FILENAME $qgis_project_path;
+            fastcgi_param QUERY_STRING    $query_string&MAP=$qgis_project_path;
+            
+            fastcgi_param  HTTPS $qgis_ssl;
+            fastcgi_param  SERVER_NAME $qgis_host;
+            fastcgi_param  SERVER_PORT $qgis_port;
+            include fastcgi_params;
+        }
         location ~ ^/nginx/(?<session_id>[-_a-zA-Z0-9]+)/(.*)$ {
             root /var/www/data;
             fastcgi_pass  qgis-fcgi;


### PR DESCRIPTION
# Description
<!--
    Please include a sufficient desciption of what this pull request does (if it's not self-explanatory from the issue)
-->

Issue: #88 

The solution in this PR is basically dedicate map.qgz, in data/server/ to always serve static trees. That project is never modified and just exists in the directory, so trees can always be retrieved by the server.

# What needs to be tested
<!--
    Please clearly indicate here what needs to be tested
-->

- [x] Repeat the flow described in the issue
- [x] Make sure the trees are loaded correctly
- [x] Also can test a bigger BBOX in deckUtils.ts, which is currently commented out

